### PR TITLE
Add time method to Metrics trait, with implementation in DogstatsdMetrics

### DIFF
--- a/api/src/main/scala/com/pagerduty/metrics/Metrics.scala
+++ b/api/src/main/scala/com/pagerduty/metrics/Metrics.scala
@@ -48,6 +48,15 @@ trait Metrics {
   def recordEvent(event: Event): Unit
 
   /**
+    * Time the provided function as the named metric, tagging success and failure automatically.
+    *
+    * @param name Name of the metric
+    * @param tags Extra tags, e.g. for DogStatsD
+    * @param f Function to time
+    */
+  def time[T](name: String, tags: (String, String)*)(f: => T): T
+
+  /**
     * If your implementation needs it, you can override this to handle a signal
     * to stop collecting metrics (close sockets, stop threads collecting gauges,
     * etcetera. The default implementation is a no-op.

--- a/api/src/main/scala/com/pagerduty/metrics/NullMetrics.scala
+++ b/api/src/main/scala/com/pagerduty/metrics/NullMetrics.scala
@@ -4,18 +4,13 @@ package com.pagerduty.metrics
   * In case you don't want to do metrics, wire up with this implementation which
   * is just a list of no-ops.
   */
-object NullMetrics extends Metrics {
+trait NoopMetrics extends Metrics {
   override def histogram(name: String, value: Int, tags: (String, String)*): Unit = {}
   override def recordEvent(event: Event): Unit = {}
   override def count(name: String, count: Int, tags: (String, String)*): Unit = {}
+  override def time[T](name: String, tags: (String, String)*)(f: => T): T = f
 }
 
-/**
-  * In case you don't want to do metrics, wire up with this implementation which
-  * is just a list of no-ops.
-  */
-class NullMetrics extends Metrics {
-  override def histogram(name: String, value: Int, tags: (String, String)*): Unit = {}
-  override def recordEvent(event: Event): Unit = {}
-  override def count(name: String, count: Int, tags: (String, String)*): Unit = {}
-}
+object NullMetrics extends Metrics with NoopMetrics
+
+class NullMetrics extends Metrics with NoopMetrics

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,9 @@ lazy val dogstatsd = (project in file("dogstatsd")).
   settings(
     name := "metrics-dogstatsd",
     libraryDependencies ++= Seq(
-      "com.indeed" % "java-dogstatsd-client" % "2.0.13"
+      "com.indeed" % "java-dogstatsd-client" % "2.0.13",
+      "org.scalatest" %% "scalatest" % "2.2.6" % "test",
+      "org.mockito" % "mockito-core" % "1.10.19" % "test" // because ScalaMock doesn't work with StatsDClient
     )
   )
 

--- a/dogstatsd/src/test/scala/com/pagerduty/metrics/pdstats/DogstatsdMetricsSpec.scala
+++ b/dogstatsd/src/test/scala/com/pagerduty/metrics/pdstats/DogstatsdMetricsSpec.scala
@@ -1,0 +1,49 @@
+package com.pagerduty.metrics.pdstats
+
+import com.timgroup.statsd.StatsDClient
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{FreeSpecLike, Matchers => ScalaTestMatchers}
+import org.mockito.Mockito._
+import org.mockito.Matchers
+
+class DogstatsdMetricsSpec extends FreeSpecLike with MockitoSugar with ScalaTestMatchers {
+
+  val mockStatsd = mock[StatsDClient]
+
+  "DogstatsdMetrics" - {
+    val metrics = new DogstatsdMetrics(mockStatsd)
+
+    val name = "some-metric"
+    val tags = ("tag-name", "tag-value")
+
+    "times a method that returns a result" in {
+      val result = 123
+
+      metrics.time(name, tags) { result } should equal (result)
+
+      verify(mockStatsd).histogram(
+        Matchers.eq(s"${name}_msec"),
+        Matchers.anyLong(),
+        Matchers.eq(s"${tags._1}:${tags._2}"),
+        Matchers.eq("success:true")
+      )
+    }
+
+    "times a method that throws an exception" in {
+      val exception = new RuntimeException("test exception")
+
+      val thrown = the [RuntimeException] thrownBy metrics.time(name, tags) { throw exception }
+      thrown should equal (exception)
+
+      verify(mockStatsd).histogram(
+        Matchers.eq(s"${name}_msec"),
+        Matchers.anyLong(),
+        Matchers.eq(s"${tags._1}:${tags._2}"),
+        Matchers.eq("success:false"),
+        Matchers.eq("exceptionClass:javalangRuntimeException")
+      )
+
+    }
+  }
+
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.8"
+version in ThisBuild := "1.1.0"


### PR DESCRIPTION
We time things all over the place, and the `Metrics` API should allow for that.

The implementation in `DogstatsdMetrics` is a simplified version of https://github.com/PagerDuty/pd-stats/blob/master/src/main/scala/com/pagerduty/stats/PdStats.scala#L85, with the "extra tags" bit removed (because nobody, including the author, used them). It keeps the success/failure tags that we rely on though.

Primary motivator for this is allowing us to provide a working implementation of https://github.com/PagerDuty/scala-kafka-consumer/blob/master/main/src/main/scala/com/pagerduty/kafkaconsumer/SimpleKafkaConsumer.scala#L340.