### PR TITLE
Add gauges with strobe reading.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,55 @@ libraryDependencies += "com.pagerduty" %% "metrics-api" % VersionString
 libraryDependencies += "com.pagerduty" %% "metrics-dogstatsd" % VersionString
 ```
 
+#Usage
+
+
+
+
+## Scheduled Gauge Checks
+
+The `GaugeReporter` may be used to automatically strobe gauges and report values back to the metric
+implementation. An application will generally only require one instance, but this is not a
+restriction.  The `GaugeReporter` is thread safe and can be modified at any point of time and
+shared across threads.
+
+Gauges may be added to a reporter using the `addGauge` method, which takes a name and reading
+provider. The reading provider must be thread safe and should not block for long periods of time, as
+this will hold up the reporter thread.
+
+```
+val metrics: Metrics = new ...
+val gauges: GaugeReporter = new GaugeReporter(metrics)
+gauges.addGauges(GaugeReporter.jvmGauges)
+gauges.addGauge("login.failure.count", () => loginFailureLongAdder.get())
+gauges.addGauge("login.success.count", () => loginSuccessLongAdder.get())
+gauges.start()
+
+...
+
+gauges.stop()
+
+```
+
+When a `GaugeProider` throws an `Exception`, it will be logged and execution will continue. In the case of a
+`Throwable`, the reporting thread will die and no further readings will be performed.
+
+
+### Provided Gauges
+
+Several canned gauges are provided and may be passed to `addGauges`:
+
+* jvmGauges - All JVM metrics listed below
+* gcGauges - All garbage collector statistics
+* systemGauges - Process uptime and processor count
+* memoryGauges - Usage statistics of heap, non-heap, and individual pools
+* threadsGauges - Thread counts and states
+
+
 License
 =======
 
-Copyright 2016, PagerDuty, Inc.
+Copyright 2016-2017, PagerDuty, Inc.
 
 This work is licensed under the [Apache Software License](https://www.apache.org/licenses/LICENSE-2.0).
 

--- a/api/src/main/scala/com/pagerduty/metrics/GaugeReporter.scala
+++ b/api/src/main/scala/com/pagerduty/metrics/GaugeReporter.scala
@@ -1,0 +1,224 @@
+package com.pagerduty.metrics
+
+import java.lang.management.{ManagementFactory, MemoryPoolMXBean, GarbageCollectorMXBean}
+import java.time.Duration
+import java.util.Objects
+import java.util.concurrent.{CopyOnWriteArrayList, Executors, ScheduledExecutorService, ScheduledFuture, TimeUnit}
+import java.util.concurrent.atomic.AtomicReference
+import java.util.function.Consumer
+import java.util.logging.{Logger, Level => LogLevel};
+
+import scala.collection.JavaConversions._
+
+/**
+ * Periodically polls a number of gauges and reports their values to a metrics
+ * collector. Readings will not be collected until {@link #start} is invoked and
+ * will not be collected after {@link #stop} is invoked.
+ * <p>
+ * New gauges may be added at any time by through the {@link #addGauge} method.
+ * Values for these new gauges will be picked-up on the next tick (as specified
+ * by the <code>delay</code> parameter.
+ * <p>
+ * Instances of GaugeReporter are thread safe and reusable.
+ *
+ * @param metrics The metric repo into which gauge readings will be sent.
+ * @param delay The delay between gauge readings. Default of 60 seconds.
+ * @param executor The scheduling executor to use.
+ */
+class GaugeReporter (
+  private val metrics: Metrics,
+  private val delay: Duration = Duration.ofSeconds(60),
+  private val executor: ScheduledExecutorService = Executors.newScheduledThreadPool(1)
+) {
+  import GaugeReporter._
+
+  private val log: Logger = Logger.getLogger(classOf[GaugeReporter].getSimpleName())
+  private val task: AtomicReference[ScheduledFuture[_]] = new AtomicReference()
+  private val gauges: CopyOnWriteArrayList[Gauge] = new CopyOnWriteArrayList()
+
+  private final class Run extends Runnable {
+    override def run(): Unit = {
+      gauges.forEach(new Consumer[Gauge] {
+        def accept(gauge: Gauge) {
+          report(gauge)
+        }
+      })
+    }
+
+    private def report(gauge: Gauge): Unit = {
+      try {
+        metrics.recordGauge(gauge._1, gauge._2(), gauge._3: _*)
+      } catch {
+        case ex: Exception => log.log(LogLevel.WARNING, "Caught unhandled exception collecting from gauge.", ex)
+        case t: Throwable => {
+          log.log(LogLevel.SEVERE, "Encountered an unhandled throwable. The system is in an unknown state. "
+            + "This thread will die and no more gauges will be collected.", t)
+          throw t
+        }
+      }
+    }
+  }
+
+  /**
+   * Add a new gauge to this reporter. These gauges will be picked-up on the
+   * next tick.
+   *
+   * @param name The name of this gauge.
+   * @param provider The gauge provider.
+   * @param tags Optional listing of key/value tags.
+   * @throws NullPointerException if name or tags are null.
+   */
+  def addGauge(name: String, provider: GaugeProvider, tags: (String, String)*): Unit = {
+    this.gauges.add((
+      Objects.requireNonNull(name, "A gauge name must be provided."),
+      Objects.requireNonNull(provider, "A gauge reading provider must be provided."),
+      tags.toArray
+    ))
+  }
+
+  /**
+   * Add all gauges to this reporter. These gauges will be picked-up on the next
+   * tick.
+   *
+   * @param gauges A set of gauges.
+   * @throws NullPointerException if name or tags of any gauge are null.
+   */
+  def addGauges(gauges: Seq[Gauge]): Unit = {
+    gauges.foreach(g => addGauge(g._1, g._2, g._3:_*))
+  }
+
+  /**
+   * Start the newly-created instance. This method may be invoked exactly once
+   * at any time. Gauges that have already been added will be reported on the
+   * first tick, and gauges added after starting will be reported on the next
+   * tick.
+   *
+   * @throws IllegalArgumentException If this instance has already been started.
+   */
+  def start(): Unit = this.synchronized {
+    if (this.task.get() != null) {
+      throw new IllegalStateException("The reporter thread has already been started and may not be started again.")
+    }
+    this.task.lazySet(this.executor.scheduleAtFixedRate(
+      new Run(),
+      delay.toMillis,
+      delay.toMillis,
+      TimeUnit.MILLISECONDS
+    ))
+  }
+
+  /**
+   * Attempts to gracefully stop this instance and allow any currently-executing
+   * reads to complete. If, after 1 minute, the executor has not gracefully shut
+   * down, it is forcibly stopped, interrupting all in-progress threads.
+   */
+  def stop(): Unit = this.synchronized {
+    val task: Option[ScheduledFuture[_]] = Option(this.task.get())
+    task.map { _.cancel(false) }
+
+    this.executor.shutdown()
+
+    try {
+      if (!this.executor.awaitTermination(1, TimeUnit.MINUTES)) {
+        task.map { _.cancel(true) }
+        this.executor.shutdownNow()
+      }
+    } catch {
+      case ex: InterruptedException => {
+        this.executor.shutdownNow()
+        Thread.currentThread.interrupt()
+      }
+    }
+  }
+}
+
+object GaugeReporter {
+  type Gauge = (String, GaugeProvider, Array[(String, String)])
+  type GaugeProvider = () => Long
+
+  val formatter = java.util.regex.Pattern.compile("\\s+")
+
+  def jvmGauges(tags: (String, String)*): Seq[Gauge] = {
+    val prefix = "jvm"
+    systemGauges("jvm", tags:_*) ++
+      gcGauges("jvm", tags:_*) ++
+      threadGauges("jvm", tags:_*) ++
+      memoryGauges("jvm", tags:_*)
+  }
+
+  def systemGauges(prefix: String, tags: (String, String)*): Seq[Gauge] = {
+    val tagArray = tags.toArray
+    Seq(
+      (prefix + ".system.uptime", () => ManagementFactory.getRuntimeMXBean.getUptime, tagArray),
+      (prefix + ".system.processors", () => ManagementFactory.getOperatingSystemMXBean.getAvailableProcessors, tagArray)
+    )
+  }
+
+  def gcGauges(prefix: String, tags: (String, String)*): Seq[Gauge] = {
+    val tagArray = tags.toArray
+    val gc: Seq[GarbageCollectorMXBean] = ManagementFactory.getGarbageCollectorMXBeans.toSeq
+    gc.flatMap{ c =>
+      val name = formatter.matcher(c.getName).replaceAll("-")
+      Seq(
+        (prefix + s".gc.${name}.count", () => c.getCollectionCount, tagArray),
+        (prefix + s".gc.${name}.time", () => c.getCollectionTime, tagArray)
+      )
+    }
+  }
+
+  def threadGauges(prefix: String, tags: (String, String)*): Seq[Gauge] = {
+    val tagArray = tags.toArray
+    val threads = ManagementFactory.getThreadMXBean
+    val states = threads.getThreadInfo(threads.getAllThreadIds, 0).toSeq
+    Seq(
+      (prefix + ".threads.count", () => threads.getThreadCount, tagArray),
+      (prefix + ".threads.runnable", () => states.filter{ t => t.getThreadState == Thread.State.RUNNABLE }.size, tagArray),
+      (prefix + ".threads.blocked", () => states.filter{ t => t.getThreadState == Thread.State.BLOCKED }.size, tagArray),
+      (prefix + ".threads.waiting", () => states.filter{ t => t.getThreadState == Thread.State.WAITING }.size, tagArray),
+      (prefix + ".threads.timed-waiting", () => states.filter{ t => t.getThreadState == Thread.State.TIMED_WAITING }.size, tagArray)
+    )
+  }
+
+  def memoryGauges(prefix: String, tags: (String, String)*): Seq[Gauge] = {
+    val tagArray = tags.toArray
+
+    val poolGauges: Seq[Gauge] = ManagementFactory.getMemoryPoolMXBeans.toSeq.flatMap { pool =>
+      val name = formatter.matcher(pool.getName).replaceAll("-")
+      val usage = pool.getUsage
+      val committed = usage.getCommitted
+      val used = usage.getUsed
+      val max = usage.getMax
+      Seq(
+        (prefix + s".pools.${name}.init", () => usage.getInit, tagArray),
+        (prefix + s".pools.${name}.used", () => used, tagArray),
+        (prefix + s".pools.${name}.usage", () => ratio(used, committed, max), tagArray),
+        (prefix + s".pools.${name}.committed", () => committed, tagArray),
+        (prefix + s".pools.${name}.max", () => max, tagArray)
+      )
+    }
+
+    val memory = ManagementFactory.getMemoryMXBean
+    val heap = memory.getHeapMemoryUsage
+    val nonHeap = memory.getNonHeapMemoryUsage
+    val memoryGauges: Seq[Gauge] = Seq(
+      (prefix + ".memory.heap.init", () => heap.getInit, tagArray),
+      (prefix + ".memory.heap.used", () => heap.getUsed, tagArray),
+      (prefix + ".memory.heap.usage", () => ratio(heap.getUsed, heap.getCommitted, heap.getMax), tagArray),
+      (prefix + ".memory.heap.committed", () => heap.getCommitted, tagArray),
+      (prefix + ".memory.heap.max", () => heap.getMax, tagArray),
+
+      (prefix + ".memory.non-heap.init", () => nonHeap.getInit, tagArray),
+      (prefix + ".memory.non-heap.used", () => nonHeap.getUsed, tagArray),
+      (prefix + ".memory.non-heap.usage", () => ratio(nonHeap.getUsed, nonHeap.getCommitted, nonHeap.getMax), tagArray),
+      (prefix + ".memory.non-heap.committed", () => nonHeap.getCommitted, tagArray),
+      (prefix + ".memory.non-heap.max", () => nonHeap.getMax, tagArray),
+
+      (prefix + ".memory.finalizer-queue.count", () => memory.getObjectPendingFinalizationCount, tagArray)
+    )
+
+    poolGauges ++ memoryGauges
+  }
+
+  private def ratio(used: Long, committed: Long, max: Long): Long =
+    (used.toDouble / Math.max(committed, max) * 100).toLong
+}

--- a/api/src/main/scala/com/pagerduty/metrics/Metrics.scala
+++ b/api/src/main/scala/com/pagerduty/metrics/Metrics.scala
@@ -47,6 +47,17 @@ trait Metrics {
     */
   def recordEvent(event: Event): Unit
 
+
+  /**
+   * Records the current reading of a gauge, which represents a point-in-time
+   * reading of a measurable thing.
+   *
+   * @param name Name of the metric.
+   * @param value The current gauge value.
+   * @param tags Extra tags
+   */
+  def recordGauge(name: String, value: Long, tags: (String, String)*): Unit
+
   /**
     * Time the provided function as the named metric, tagging success and failure automatically.
     *

--- a/api/src/main/scala/com/pagerduty/metrics/NullMetrics.scala
+++ b/api/src/main/scala/com/pagerduty/metrics/NullMetrics.scala
@@ -7,6 +7,7 @@ package com.pagerduty.metrics
 trait NoopMetrics extends Metrics {
   override def histogram(name: String, value: Int, tags: (String, String)*): Unit = {}
   override def recordEvent(event: Event): Unit = {}
+  override def recordGauge(name: String, count: Long, tags: (String, String)*): Unit = {}
   override def count(name: String, count: Int, tags: (String, String)*): Unit = {}
   override def time[T](name: String, tags: (String, String)*)(f: => T): T = f
 }

--- a/api/src/test/scala/com/pagerduty/metrics/GuageReporterSpec.scala
+++ b/api/src/test/scala/com/pagerduty/metrics/GuageReporterSpec.scala
@@ -1,0 +1,41 @@
+package com.pagerduty.metrics
+
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{FreeSpecLike, Matchers => ScalaTestMatchers}
+import org.mockito.Mockito
+import org.mockito.Mockito._
+import java.time.Duration
+import java.util.concurrent.{CountDownLatch, ThreadLocalRandom, TimeUnit}
+
+class GaugeReporterSpec extends FreeSpecLike with MockitoSugar with ScalaTestMatchers {
+  val metrics: Metrics = mock[Metrics]
+
+  "GaugeReporterSpec" - {
+    val name = "yay-metrics"
+    val tags = Seq(("name", "value"), ("key", "value"))
+
+    "delegates to the gauge 3 times" in {
+      val result = ThreadLocalRandom.current.nextLong
+
+      // Ew, nasty thread tests. But it's gotta happen :(
+      val reporter: GaugeReporter = new GaugeReporter(metrics, Duration.ofMillis(5))
+
+      val latch: CountDownLatch = new CountDownLatch(3)
+      val provider = () => {
+        latch.countDown()
+        result
+      }
+
+      reporter.addGauge(name, provider, tags:_*)
+
+      try {
+        reporter.start()
+        latch.await(1, TimeUnit.SECONDS)
+      } finally {
+        reporter.stop()
+      }
+
+      verify(metrics, Mockito.atLeast(3)).recordGauge(name, result, tags: _*)
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,11 @@ lazy val sharedSettings = Seq(
   licenses += ("MIT", url("http://opensource.org/licenses/MIT")),
   bintrayOrganization := Some("pagerduty"),
   bintrayRepository := "oss-maven",
-  publishMavenStyle := true
+  publishMavenStyle := true,
+  libraryDependencies ++= Seq(
+    "org.scalatest" %% "scalatest" % "2.2.6" % "test",
+    "org.mockito" % "mockito-core" % "1.10.19" % "test" // because ScalaMock doesn't work with StatsDClient
+  )
 )
 
 lazy val api = (project in file("api")).
@@ -21,9 +25,7 @@ lazy val dogstatsd = (project in file("dogstatsd")).
   settings(
     name := "metrics-dogstatsd",
     libraryDependencies ++= Seq(
-      "com.indeed" % "java-dogstatsd-client" % "2.0.13",
-      "org.scalatest" %% "scalatest" % "2.2.6" % "test",
-      "org.mockito" % "mockito-core" % "1.10.19" % "test" // because ScalaMock doesn't work with StatsDClient
+      "com.indeed" % "java-dogstatsd-client" % "2.0.13"
     )
   )
 

--- a/dogstatsd/src/main/scala/com/pagerduty/metrics/pdstats/DogstatsdMetrics.scala
+++ b/dogstatsd/src/main/scala/com/pagerduty/metrics/pdstats/DogstatsdMetrics.scala
@@ -41,6 +41,10 @@ class DogstatsdMetrics(client: StatsDClient, standardTags: (String, String)*) ex
   override def recordEvent(event: Event): Unit =
     client.recordEvent(convertEvent(event))
 
+  override def recordGauge(name: String, value: Long, tags: (String, String)*): Unit = {
+    client.gauge(clean(name), value, mkTags(tags):_*)
+  }
+
   override def count(name: String, count: Int, tags: (String, String)*): Unit =
     client.count(clean(name), count, mkTags(tags):_*)
 


### PR DESCRIPTION
This change adds a `GaugeReporter`, which may be used to automatically
strobe gauges and report values back to the metric implementation. An
application will generally only require one instance, but this is not a
restriction.  The `GaugeReporter` is thread safe and can be modified at
any point of time and shared across threads.

Gauges may be added to a reporter using the `addGauge` method, which
takes a name and reading provider. The reading provider must be thread
safe and should not block for long periods of time, as this will hold up
the reporter thread.

This change also adds in a number of very useful, common-scenario gauges
covering the most common JVM metrics, such as threads, memory, and
garbage collection statistics. These sets may be added with the
`addGauges` method, such as `addGauges(jvmGauges())`.