### PR TITLE
Add gauge support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Also, it's probably time for a generic metrics API to do to metrics what SLF4J's
 logging. For now, this API does not aspire to be it - it's very Dogstatsd-oriented, because
 that's what we use, but we didn't want people using our libraries to get locked in.
 
+## Sub-Modules
+
+- metrics-api is the generic API artifact
+- metrics-dogstatsd is the DataDog implementation of the API
+- metrics-gauge provides `GaugeReporter`, a class which samples `Gauge`s and reports the result
+
 ## Installation
 
 - This set of libraries is published to PagerDuty Bintray OSS Maven repository. Add it to your resolvers (PD developers can skip this step):

--- a/api/src/main/scala/com/pagerduty/metrics/Metrics.scala
+++ b/api/src/main/scala/com/pagerduty/metrics/Metrics.scala
@@ -40,6 +40,17 @@ trait Metrics {
   def increment(name: String, tags: (String, String)*): Unit = count(name, 1, tags: _*)
 
   /**
+   * Records the current reading of a gauge, which represents a point-in-time
+   * reading of a measurable thing.
+   *
+   * @param name Name of the gauge
+   * @param value The current gauge value
+   * @param tags Extra tags
+   */
+  def gauge(name: String, value: Long, tags: (String, String)*): Unit
+  def gauge(name: String, value: Double, tags: (String, String)*): Unit
+
+  /**
     * Record an event. Events are things that happen that - in Datadog for example -
     * you can overlay over a graph.
     *

--- a/api/src/main/scala/com/pagerduty/metrics/NullMetrics.scala
+++ b/api/src/main/scala/com/pagerduty/metrics/NullMetrics.scala
@@ -5,10 +5,12 @@ package com.pagerduty.metrics
   * is just a list of no-ops.
   */
 trait NoopMetrics extends Metrics {
-  override def histogram(name: String, value: Int, tags: (String, String)*): Unit = {}
-  override def recordEvent(event: Event): Unit = {}
-  override def count(name: String, count: Int, tags: (String, String)*): Unit = {}
-  override def time[T](name: String, tags: (String, String)*)(f: => T): T = f
+  def histogram(name: String, value: Int, tags: (String, String)*): Unit = {}
+  def gauge(name: String, value: Long, tags: (String, String)*): Unit = {}
+  def gauge(name: String, value: Double, tags: (String, String)*): Unit = {}
+  def recordEvent(event: Event): Unit = {}
+  def count(name: String, count: Int, tags: (String, String)*): Unit = {}
+  def time[T](name: String, tags: (String, String)*)(f: => T): T = f
 }
 
 object NullMetrics extends Metrics with NoopMetrics

--- a/build.sbt
+++ b/build.sbt
@@ -6,13 +6,27 @@ lazy val sharedSettings = Seq(
   licenses += ("MIT", url("http://opensource.org/licenses/MIT")),
   bintrayOrganization := Some("pagerduty"),
   bintrayRepository := "oss-maven",
-  publishMavenStyle := true
+  publishMavenStyle := true,
+  libraryDependencies ++= Seq(
+    "org.scalatest" %% "scalatest" % "2.2.6" % Test,
+    "org.scalamock" %% "scalamock-scalatest-support" % "3.5.0" % Test
+  )
 )
 
 lazy val api = (project in file("api")).
   settings(sharedSettings: _*).
   settings(
     name := "metrics-api"
+  )
+
+lazy val gauge = (project in file("gauge")).
+  dependsOn(api).
+  settings(sharedSettings: _*).
+  settings(
+    name := "metrics-gauge",
+    libraryDependencies ++= Seq(
+      "org.slf4j" % "slf4j-api" % "1.7.25"
+    )
   )
 
 lazy val dogstatsd = (project in file("dogstatsd")).
@@ -22,16 +36,14 @@ lazy val dogstatsd = (project in file("dogstatsd")).
     name := "metrics-dogstatsd",
     libraryDependencies ++= Seq(
       "com.indeed" % "java-dogstatsd-client" % "2.0.13",
-      "org.scalatest" %% "scalatest" % "2.2.6" % "test",
       "org.mockito" % "mockito-core" % "1.10.19" % "test" // because ScalaMock doesn't work with StatsDClient
     )
   )
 
-lazy val root = Project(
-  id = "root",
-  base = file("."),
-  aggregate = Seq(api, dogstatsd),
-  settings = Project.defaultSettings ++ Seq(
+lazy val root = Project(id = "root", base = file(".")).
+  dependsOn(api, gauge, dogstatsd).
+  aggregate(api, gauge, dogstatsd).
+  settings(Defaults.coreDefaultSettings ++ Seq(
     publishLocal := {},
     publish := {},
     publishArtifact := false

--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,7 @@ lazy val root = Project(id = "root", base = file(".")).
   settings(Defaults.coreDefaultSettings ++ Seq(
     publishLocal := {},
     publish := {},
-    publishArtifact := false
+    publishArtifact := false,
+    bintrayReleaseOnPublish := false
   )
 )

--- a/dogstatsd/src/main/scala/com/pagerduty/metrics/pdstats/DogstatsdMetrics.scala
+++ b/dogstatsd/src/main/scala/com/pagerduty/metrics/pdstats/DogstatsdMetrics.scala
@@ -35,16 +35,24 @@ class DogstatsdMetrics(client: StatsDClient, standardTags: (String, String)*) ex
 
   private def mkTags(tags: Seq[(String,String)]) = tagsToSeq(standardTags ++ tags)
 
-  override def histogram(name: String, value: Int, tags: (String, String)*): Unit =
+  def histogram(name: String, value: Int, tags: (String, String)*): Unit =
     client.histogram(clean(name), value, mkTags(tags):_*)
 
-  override def recordEvent(event: Event): Unit =
+  def gauge(name: String, value: Long, tags: (String, String)*): Unit = {
+    client.gauge(clean(name), value, mkTags(tags):_*)
+  }
+
+  def gauge(name: String, value: Double, tags: (String, String)*): Unit = {
+    client.gauge(clean(name), value, mkTags(tags):_*)
+  }
+
+  def recordEvent(event: Event): Unit =
     client.recordEvent(convertEvent(event))
 
-  override def count(name: String, count: Int, tags: (String, String)*): Unit =
+  def count(name: String, count: Int, tags: (String, String)*): Unit =
     client.count(clean(name), count, mkTags(tags):_*)
 
-  override def time[T](name: String, tags: (String, String)*)(f: => T): T = {
+  def time[T](name: String, tags: (String, String)*)(f: => T): T = {
     val stopwatch = Stopwatch.start()
     val tryResult = Try(f)
     val durationMillis = stopwatch.elapsed().toMillis.toInt

--- a/gauge/src/main/scala/com/pagerduty/metrics/gauge/Gauge.scala
+++ b/gauge/src/main/scala/com/pagerduty/metrics/gauge/Gauge.scala
@@ -1,0 +1,5 @@
+package com.pagerduty.metrics.gauge
+
+trait Gauge[SampleType] {
+  def sample(): SampleType
+}

--- a/gauge/src/main/scala/com/pagerduty/metrics/gauge/GaugeReporter.scala
+++ b/gauge/src/main/scala/com/pagerduty/metrics/gauge/GaugeReporter.scala
@@ -1,0 +1,71 @@
+package com.pagerduty.metrics.gauge
+
+import org.slf4j.LoggerFactory
+
+import java.util.concurrent.{ Executors, ScheduledExecutorService, ThreadFactory, TimeUnit }
+
+import scala.concurrent.duration._
+import scala.util.control.NonFatal
+
+/**
+  * The GaugeReporter samples Gauges and reports the result to user-provided consumers.
+  *
+  * Depending on the number of gauges that will be added to this Reporter, the samplePeriod of those gauges,
+  * and the runtime duration of the gauges' consumers, threadPoolSize should be adjusted.
+  */
+class GaugeReporter(threadPoolSize: Int = 1) {
+  private val log = LoggerFactory.getLogger(getClass)
+
+  private val executor = buildGaugeExecutorService(threadPoolSize)
+
+  /**
+    * Add a gauge to be sampled at the given period. The sample returned from the gauge will be
+    * provided to the given sampleConsumers.
+    *
+    * The gauge will be sampled immediately when this method is called.
+    *
+    * If running the sampleConsumers takes longer than the samplePeriod, the next sample may start late,
+    * but will not run concurrently.
+    */
+  def addGauge[T](gauge: Gauge[T], sampleConsumers: Set[(T) => Unit], samplePeriod: FiniteDuration = 1.minute): Unit = {
+    val gaugeRunnable = new Runnable {
+      override def run(): Unit = {
+        try {
+          val sample = gauge.sample
+          sampleConsumers foreach { sc =>
+            try {
+              sc.apply(sample)
+            } catch {
+              case NonFatal(e) => log.error("Error consuming gauge sample: ", e)
+            }
+          }
+        } catch {
+          case NonFatal(e) => log.error("Error sampling gauge: ", e)
+        }
+      }
+    }
+
+    executor.scheduleWithFixedDelay(gaugeRunnable, 0, samplePeriod.toMillis, TimeUnit.MILLISECONDS)
+  }
+
+  /**
+    * Stop sampling all gauges and shutdown underlying resources.
+    */
+  def stop(): Unit = {
+    executor.shutdownNow()
+  }
+
+  private def buildGaugeExecutorService(size: Int): ScheduledExecutorService = {
+    val executor: ScheduledExecutorService = Executors.newScheduledThreadPool(
+      size,
+      new ThreadFactory() {
+        override def newThread(runnable: Runnable): Thread = {
+          val thread = new Thread(runnable, "gauge-reporter-worker")
+          thread.setDaemon(true)
+          thread
+        }
+      }
+    )
+    executor
+  }
+}

--- a/gauge/src/main/scala/com/pagerduty/metrics/gauge/MetricsGaugeSampleConsumers.scala
+++ b/gauge/src/main/scala/com/pagerduty/metrics/gauge/MetricsGaugeSampleConsumers.scala
@@ -1,0 +1,16 @@
+package com.pagerduty.metrics.gauge
+
+import com.pagerduty.metrics.Metrics
+
+/**
+  * Some very simple glue code to make GaugeReporter report to Metrics.
+  */
+object MetricsGaugeSampleConsumers {
+  def long(metrics: Metrics, name: String, tags: (String, String)*): (Long) => Unit = {
+    (sample: Long) => metrics.gauge(name, sample, tags: _*)
+  }
+
+  def double(metrics: Metrics, name: String, tags: (String, String)*): (Double) => Unit = {
+    (sample: Double) => metrics.gauge(name, sample, tags: _*)
+  }
+}

--- a/gauge/src/test/scala/com/pagerduty/metrics/gauge/GaugeReporterSpec.scala
+++ b/gauge/src/test/scala/com/pagerduty/metrics/gauge/GaugeReporterSpec.scala
@@ -1,0 +1,52 @@
+package com.pagerduty.metrics.gauge
+
+import org.scalatest.Matchers
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.FreeSpecLike
+import org.scalatest.concurrent.Eventually
+
+import scala.concurrent.duration._
+
+class GaugeReporterSpec extends FreeSpecLike with MockFactory with Eventually with Matchers {
+
+  val sampleException = new Exception("test exception")
+  val testSample = 12345
+
+  class TestGauge extends Gauge[Int] {
+    var numSamples = 0
+
+    def sample(): Int = {
+      numSamples += 1
+      if (numSamples == 2) {
+        throw sampleException
+      } else {
+        testSample
+      }
+    }
+  }
+
+  "A GaugeReporter" - {
+    val gaugeReporter = new GaugeReporter
+
+    "periodically sample a gauge, reporting results and ignoring failures" in {
+      val gauge = new TestGauge
+      val consumer1 = mockFunction[Int, Unit]
+      val consumer2 = mockFunction[Int, Unit]
+      val consumer3 = mockFunction[Int, Unit]
+
+      // there's a bit of variability on the number of times the gauge is actually sampled
+      consumer1.expects(testSample).repeat(4 to 5)
+      consumer2.expects(testSample).repeat(4 to 5).throws(new RuntimeException("simulated exception"))
+      consumer3.expects(testSample).repeat(4 to 5)
+
+      gaugeReporter.addGauge[Int](gauge, Set(consumer1, consumer2, consumer3), 200.milliseconds)
+
+      eventually(timeout(1000.milliseconds)) {
+        gauge.numSamples should be >= 5 // again, could be 6 in some cases
+      }
+
+      gaugeReporter.stop
+    }
+  }
+
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.1"
+version in ThisBuild := "1.3.0"


### PR DESCRIPTION
This PR adds support for reporting gauge values in the `Metrics` API, and implements the new methods in `DogstatsdMetrics`.

It also adds a new artifact, `metrics-gauge`. This artifact defines `Gauge` and `GaugeReporter`. `GaugeReporter` periodically samples `Gauges` and reports the sample to user-defined consumers (could be a Metrics instance, see `MetricsGaugeSampleConsumers`).

Some of the above code is based on the [Gauge stuff in Scheduler](https://github.com/PagerDuty/scheduler/tree/master/scheduler/src/main/scala/com/pagerduty/scheduler/gauge). But, the `callbacks`/`sampleConsumers` have been moved into the `GaugeReporter` for simplicity... and because it makes more sense that way. Inspiration also taken from #8. The code in Scheduler will be replaced with this.

Cleaned up a few styles things (no need for `override` when you're implementing an abstract method).

TODO before merge:

- [x] dogfood in scheduler
- [x] bump version

Internal ticket: CORE-1206