### PR TITLE
Add recordEvent method with tags

### DIFF
--- a/api/src/main/scala/com/pagerduty/metrics/Metrics.scala
+++ b/api/src/main/scala/com/pagerduty/metrics/Metrics.scala
@@ -59,6 +59,15 @@ trait Metrics {
   def recordEvent(event: Event): Unit
 
   /**
+    * Record an event. Events are things that happen that - in Datadog for example -
+    * you can overlay over a graph.
+    *
+    * @param event Event to submit
+    * @param tags Extra tags
+    */
+  def recordEvent(event: Event, tags: (String, String)*): Unit
+
+  /**
     * Time the provided function as the named metric, tagging success and failure automatically.
     *
     * @param name Name of the metric

--- a/api/src/main/scala/com/pagerduty/metrics/NullMetrics.scala
+++ b/api/src/main/scala/com/pagerduty/metrics/NullMetrics.scala
@@ -9,6 +9,7 @@ trait NoopMetrics extends Metrics {
   def gauge(name: String, value: Long, tags: (String, String)*): Unit = {}
   def gauge(name: String, value: Double, tags: (String, String)*): Unit = {}
   def recordEvent(event: Event): Unit = {}
+  def recordEvent(event: Event, tags: (String, String)*): Unit = {}
   def count(name: String, count: Int, tags: (String, String)*): Unit = {}
   def time[T](name: String, tags: (String, String)*)(f: => T): T = f
 }

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val dogstatsd = (project in file("dogstatsd")).
   settings(
     name := "metrics-dogstatsd",
     libraryDependencies ++= Seq(
-      "com.indeed" % "java-dogstatsd-client" % "2.0.13",
+      "com.datadoghq" % "java-dogstatsd-client" % "2.7",
       "org.mockito" % "mockito-core" % "1.10.19" % "test" // because ScalaMock doesn't work with StatsDClient
     )
   )

--- a/dogstatsd/src/main/scala/com/pagerduty/metrics/pdstats/DogstatsdMetrics.scala
+++ b/dogstatsd/src/main/scala/com/pagerduty/metrics/pdstats/DogstatsdMetrics.scala
@@ -49,6 +49,9 @@ class DogstatsdMetrics(client: StatsDClient, standardTags: (String, String)*) ex
   def recordEvent(event: Event): Unit =
     client.recordEvent(convertEvent(event))
 
+  def recordEvent(event: Event, tags: (String, String)*): Unit =
+    client.recordEvent(convertEvent(event), mkTags(tags):_*)
+
   def count(name: String, count: Int, tags: (String, String)*): Unit =
     client.count(clean(name), count, mkTags(tags):_*)
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.0.0"
+version in ThisBuild := "2.1.0"


### PR DESCRIPTION
This changeset covers the gap for `recordEvent` method between its API signature and DogstatsD implementation to allow event be accompanied with related tags.

Additionally, dependency for `java-dogstatd-client` updated to point to its upstream, that was moved from indeedeng/java-dogstatsd-client to dataDog/java-dogstatsd-client (merge was done at version 2.0.16).